### PR TITLE
Feature: Added `site` to Plugin options

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Accepted fields:
 | `applicationId` | `string` | **Required**                    | The application ID for your Datadog RUM application   |
 | `service`       | `string` | `"docusaurus"`                  | The name your service will show within the Datadog UI |
 | `env`           | `string` | `process.env.NODE_ENV ?? "dev"` | The environment of your deployed application          |
+| `site`          | `string` | `"datadoghq.com"`               | The site URL of your Datadog instance                 |
 
 To create your application:
 
@@ -50,7 +51,9 @@ To create your application:
       {
         clientToken: "3EBOWfRPv8qwertyZXCvbnMAsD2f1g0Hf96",
         applicationId: "01234567-89ab-cdef-0123-456789abcdef",
-        service: "my-docusaurus-site"
+        service: "my-docusaurus-site",
+        // if in Europe
+        site: "datadoghq.eu"
       },
     ],
   ],

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,10 +8,11 @@ import type { PluginOptions, Options } from "./options";
 
 export default function pluginDatadogRum(
   context: LoadContext,
-  { clientToken, applicationId, service, env }: PluginOptions
+  { clientToken, applicationId, service, site, env }: PluginOptions
 ): Plugin {
   service = service ?? "docusaurus";
   env = env ?? process.env.NODE_ENV ?? "dev";
+  site = site ?? "datadoghq.com";
 
   return {
     name: "docusaurus-plugin-for-datadog-rum",
@@ -33,10 +34,10 @@ DD_RUM.onReady(function() {
   DD_RUM.init({
     clientToken: '${clientToken}',
     applicationId: '${applicationId}',
-    site: 'datadoghq.com',
+    site: '${site}',
     service: '${service}',
     env: '${env}',
-    // Specify a version number to identify the deployed version of your application in Datadog 
+    // Specify a version number to identify the deployed version of your application in Datadog
     // version: '1.0.0',
     sampleRate: 100,
     trackInteractions: true,
@@ -53,6 +54,7 @@ const pluginOptionsSchema = Joi.object<PluginOptions>({
   clientToken: Joi.string().required(),
   applicationId: Joi.string().required(),
   service: Joi.string().default("docusaurus"),
+  site: Joi.string().default("datadoghq.com"),
   env: Joi.string().default(process.env.NODE_ENV ?? "dev"),
 });
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -2,6 +2,7 @@ export type PluginOptions = {
   clientToken: string;
   applicationId: string;
   service?: string;
+  site?: string;
   env?: string;
 };
 

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -39,6 +39,44 @@ describe("docusaurus-plugin-for-datadog-rum", () => {
     runEmptyTest({ applicationId: "" });
   });
 
+  test("injectHtmlTags returns default values correctly when only applicationId and clientToken are provided", () => {
+    const nodeEnv = "production";
+    process.env.NODE_ENV = nodeEnv;
+
+    const pluginOptions = getOptions(fakeOptions);
+    const result = plugin({} as unknown as LoadContext, pluginOptions);
+
+    expect(
+      result.injectHtmlTags
+        ? result.injectHtmlTags({ content: null })
+        : undefined
+    ).toEqual({
+      headTags: [
+        {
+          tagName: "script",
+          innerHTML: `(function(h,o,u,n,d) {
+  h=h[d]=h[d]||{q:[],onReady:function(c){h.q.push(c)}}
+  d=o.createElement(u);d.async=1;d.src=n
+  n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
+})(window,document,'script','https://www.datadoghq-browser-agent.com/datadog-rum.js','DD_RUM')
+DD_RUM.onReady(function() {
+  DD_RUM.init({
+    clientToken: '${pluginOptions.clientToken}',
+    applicationId: '${pluginOptions.applicationId}',
+    site: 'datadoghq.com',
+    service: 'docusaurus',
+    env: '${nodeEnv}',
+    // Specify a version number to identify the deployed version of your application in Datadog
+    // version: '1.0.0',
+    sampleRate: 100,
+    trackInteractions: true,
+  })
+})`,
+        },
+      ],
+    });
+  });
+
   function runHappyTest(options: Partial<PluginOptions>) {
     const pluginOptions = getOptions(options);
     const result = plugin({} as unknown as LoadContext, pluginOptions);

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -59,10 +59,10 @@ DD_RUM.onReady(function() {
   DD_RUM.init({
     clientToken: '${pluginOptions.clientToken}',
     applicationId: '${pluginOptions.applicationId}',
-    site: 'datadoghq.com',
+    site: '${pluginOptions.site ?? "datadoghq.com"}',
     service: '${pluginOptions.service ?? "docusaurus"}',
     env: '${pluginOptions.env ?? process.env.NODE_ENV}',
-    // Specify a version number to identify the deployed version of your application in Datadog 
+    // Specify a version number to identify the deployed version of your application in Datadog
     // version: '1.0.0',
     sampleRate: 100,
     trackInteractions: true,
@@ -86,5 +86,10 @@ DD_RUM.onReady(function() {
   test("injectHtmlTags injects the environment name correctly", () => {
     process.env.NODE_ENV = "production";
     runHappyTest({ env: "dev" });
+  });
+
+  test("injectHtmlTags injects the site name correctly", () => {
+    process.env.NODE_ENV = "production";
+    runHappyTest({ site: "datadoghq.eu" });
   });
 });


### PR DESCRIPTION
## Context

After trying to use this plugin to integrate Datadog into my Docusaurus site, I run into a permission issue due to my Datadog instance to be in Europe instead of the States. That means I have to send the proper `site` variable, which is "datadoghq.eu" for Europe instances, instead of "datadoghq.com".

This PR aims to allow the `site` variable to be sent as another option for the plugin, allowing users to configure the integration properly regardless of where their Datadog instance is based.

## Changes

* Added `site` to `PluginOptions` (`string`)
* Send the `site` variable when initializing Datadog instead of the default "datadoghq.com"
* Added a new test to check that the `site` variable is being received correctly when sent.
* Added another extra test to check that when no optional options are sent, the result has the correct default values 👍🏽 

> The new `site` variable falls back to "datadoghq.com", so no need to pass it in case you don't need a specific one. This makes this change non-breaking in case existing users upgrade to newer versions. 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
