### PR TITLE
chore: add package support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
     "prepare": "husky install"
   },
   "repository": "https://github.com/twilio-labs/docusaurus-plugin-for-datadog-rum",
+  "homepage": "https://github.com/twilio-labs/docusaurus-plugin-for-datadog-rum#readme",
+  "bugs": {
+    "url": "https://github.com/twilio-labs/docusaurus-plugin-for-datadog-rum/issues"
+  },
   "license": "MIT",
   "dependencies": {
     "@docusaurus/core": "2.0.0-beta.21",


### PR DESCRIPTION
## Summary
- add npm `homepage` metadata pointing to the repository README
- add `bugs.url` metadata pointing to the GitHub issue tracker
- leave runtime code, dependencies, and package contents unchanged

## Validation
- `yarn install --frozen-lockfile --ignore-scripts`
- `node` package metadata assertion
- `npm view @twilio-labs/docusaurus-plugin-for-datadog-rum@0.1.0 name version repository homepage bugs --json`
- `yarn build`
- `yarn test --runInBand`
- `HUSKY=0 npm pack --dry-run --json .`
- `git diff --check`